### PR TITLE
Migrate Specific Scopes without ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ $ python export_db.py --help
 usage: export_db.py [-h] [--users] [--workspace]
                     [--notebook-format {DBC,SOURCE,HTML}] [--download]
                     [--libs] [--clusters] [--jobs] [--metastore] [--secrets]
+                    [--scope-names SCOPE_NAMES [SCOPE_NAMES ...]] [--skip-scope-acl] 
                     [--metastore-unicode] [--cluster-name CLUSTER_NAME]
                     [--database DATABASE] [--iam IAM] [--skip-failed]
                     [--mounts] [--azure] [--profile PROFILE]
@@ -286,6 +287,10 @@ optional arguments:
   --metastore           log all the metastore table definitions
   --metastore-unicode   log all the metastore table definitions including
                         unicode characters
+  --secrets             log all the secret scopes                        
+  --scope-names SCOPE_NAMES [SCOPE_NAMES ...]
+                        log only the specified secret scope
+  --skip-scope-acl      Skip logging the secret ACLs during export                        
   --table-acls          log all table ACL grant and deny statements
   --cluster-name CLUSTER_NAME
                         Cluster name to export the metastore to a specific
@@ -335,6 +340,7 @@ usage: import_db.py [-h] [--users] [--workspace] [--workspace-top-level]
                     [--archive-missing] [--libs] [--clusters] [--jobs]
                     [--metastore] [--metastore-unicode] [--get-repair-log]
                     [--cluster-name CLUSTER_NAME] [--skip-failed] [--azure]
+                    [--secrets] [--scope-names SCOPE_NAMES [SCOPE_NAMES ...]] [--skip-scope-acl]                     
                     [--profile PROFILE] [--single-user SINGLE_USER]
                     [--no-ssl-verification] [--silent] [--debug]
                     [--set-export-dir SET_EXPORT_DIR] [--pause-all-jobs]
@@ -376,6 +382,10 @@ optional arguments:
                         cluster. Cluster will be started.
   --skip-failed         Skip missing users that do not exist when importing
                         user notebooks
+  --secrets             Import all secret scopes
+  --scope-names SCOPE_NAMES [SCOPE_NAMES ...]
+                        import only the specified secret scope
+  --skip-scope-acl      Skip importing the secret ACLs during export                        
   --azure               Run on Azure. (Default is AWS)
   --profile PROFILE     Profile to parse the credentials
   --no-ssl-verification

--- a/dbclient/ClustersClient.py
+++ b/dbclient/ClustersClient.py
@@ -12,7 +12,7 @@ class ClustersClient(dbclient):
         super().__init__(configs)
         self._checkpoint_service = checkpoint_service
         self.groups_to_keep = configs.get("groups_to_keep", False)
-        self.skip_missing_users = configs['skip_missing_users']
+        self.skip_missing_users = configs.get('skip_missing_users', False)
 
     create_configs = {'num_workers',
                       'autoscale',

--- a/dbclient/SecretsClient.py
+++ b/dbclient/SecretsClient.py
@@ -171,7 +171,7 @@ class SecretsClient(ClustersClient):
                     else:
                         logging.info("Skipping ACL Updates for {}".format(scope_name))
                     # loop through the scope and create the k/v pairs
-                with open(file_path, 'r', encoding="utf-8") as fp:
+                    with open(file_path, 'r', encoding="utf-8") as fp:
                         for s in fp:
                             s_dict = json.loads(s)
                             k = s_dict.get('name')

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -458,7 +458,7 @@ def build_client_config(profile, url, token, args):
     config['num_parallel'] = args.num_parallel
     config['retry_total'] = args.retry_total
     config['retry_backoff'] = args.retry_backoff
-    config['timeout'] = args.timeout if args.timeout else 86400
+    config['timeout'] = args.timeout if 'timeout' in args else 86400
     return config
 
 

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -442,8 +442,8 @@ def build_client_config(profile, url, token, args):
               'skip_failed': args.skip_failed,
               'debug': args.debug,
               'file_format': str(args.notebook_format), 
-              'timeout':args.timeout, 
-              'skip_missing_users':args.skip_missing_users
+              'timeout':args.timeout if 'timeout' in args else 86400,
+              'skip_missing_users':args.skip_missing_users if 'skip_missing_users' in args else True
               }
     # this option only exists during imports so we check for existence
     if 'overwrite_notebooks' in args:

--- a/dbclient/parser.py
+++ b/dbclient/parser.py
@@ -109,6 +109,14 @@ def get_export_parser():
     parser.add_argument('--secrets', action='store_true',
                         help='log all the secret scopes')
 
+    # get specific secret scope
+    parser.add_argument('--scope-names', type=str, action='store', nargs="+",
+                        help='log only the specified secret scope')
+
+    # Export Secret ACLs
+    parser.add_argument('--skip-scope-acl', action='store_true', default= False,
+                        help='Skip logging the secret ACLs during export')
+
     # get all mlflow experiments
     parser.add_argument('--mlflow-experiments', action='store_true',
                         help='log all the mlflow experiments')
@@ -320,6 +328,14 @@ def get_import_parser():
     parser.add_argument('--secrets', action='store_true',
                         help='Import all secret scopes')
 
+    # import only specific secret scope
+    parser.add_argument('--scope-names', type=str, action='store', nargs="+",
+                        help='import only the specified secret scope')
+
+    # Skip Importing Secret ACLs
+    parser.add_argument('--skip-scope-acl', action='store_true', default= False,
+                        help='Skip importing the secret ACLs during export')
+
     # import all mlflow experiments
     parser.add_argument('--mlflow-experiments', action='store_true',
                         help='Import all the mlflow experiments')
@@ -442,6 +458,7 @@ def build_client_config(profile, url, token, args):
     config['num_parallel'] = args.num_parallel
     config['retry_total'] = args.retry_total
     config['retry_backoff'] = args.retry_backoff
+    config['timeout'] = args.timeout if args.timeout else 86400
     return config
 
 

--- a/export_db.py
+++ b/export_db.py
@@ -188,12 +188,16 @@ def main():
         if not args.cluster_name:
             print("Please provide an existing cluster name w/ --cluster-name option\n")
             return
-        print("Export the secret scopes configs at {0}".format(now))
+        scope_names = args.scope_names if args.scope_names else None
+        print("Export the secret scopes configs at {0} for scope: {1}".format(now, scope_names))
         start = timer()
         sc = SecretsClient(client_config, checkpoint_service)
         # log job configs
-        sc.log_all_secrets(args.cluster_name)
-        sc.log_all_secrets_acls()
+        sc.log_all_secrets(args.cluster_name, secret_scopes=scope_names)
+        if not args.skip_scope_acl:
+            sc.log_all_secrets_acls()
+        else:
+            print("Skipping ACL Export")
         end = timer()
         print("Complete Secrets Export Time: " + str(timedelta(seconds=end - start)))
 

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -430,8 +430,8 @@ def diff_files(source, destination, config):
 
 
 class DiffTask(AbstractTask):
-    def __init__(self, name, source, destination, config=None):
-        super().__init__(name, wmconstants.WM_VALIDATE, name, skip=False)
+    def __init__(self, name, source, destination, config=None, skip=False):
+        super().__init__(name, wmconstants.WM_VALIDATE, name, skip)
         self.source = source
         self.destination = destination
         self.config = config
@@ -442,8 +442,8 @@ class DiffTask(AbstractTask):
 
 
 class DirDiffTask(AbstractTask):
-    def __init__(self, name, source, destination, config, suffix=None):
-        super().__init__(name, wmconstants.WM_VALIDATE, name, skip=False)
+    def __init__(self, name, source, destination, config, suffix=None, skip=False):
+        super().__init__(name, wmconstants.WM_VALIDATE, name, skip)
         self.source = source
         self.destination = destination
         self.config = config


### PR DESCRIPTION
This scenario is useful when migrating from a workspace where the ACL's do not match (Group names have changed, permissions to the groups have changed).

In addition, added two new args to allow migrating specific secret scopes. This option is available only when using export_db/import_db directly and not as part of the pipelines.